### PR TITLE
Parse only XML string instead of entire response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ mapping to response parsed by xml-js package. Classes are mapped and simplified 
 
 ```typescript
 const response = await axios.get('https://api.geekdo.com/xmlapi2/thing?id=169786&versions=1');
-const bggResponse = parseBggXmlApi2ThingResponse(response);
+const bggResponse = parseBggXmlApi2ThingResponse(response.data);
 const thing = bggResponse.item;
 ```
 
@@ -17,7 +17,7 @@ You can also get multiple things
 
 ```typescript
 const response = await axios.get('https://api.geekdo.com/xmlapi2/thing?id=170416,169786&versions=1');
-const bggResponse = parseBggXmlApi2ThingResponse(response);
+const bggResponse = parseBggXmlApi2ThingResponse(response.data);
 const thing1 = bggResponse.items[0];
 const thing2 = bggResponse.items[1];
 ```
@@ -26,7 +26,7 @@ const thing2 = bggResponse.items[1];
 
 ```typescript
 const response = await axios.get('https://api.geekdo.com/xmlapi2/search?query=scythe');
-const bggResponse = parseBggXmlApi2SearchResponse(response);
+const bggResponse = parseBggXmlApi2SearchResponse(response.data);
 const search = bggResponse.items;
 ```
 


### PR DESCRIPTION
Hey, I'm not sure if this is the best solution but to get this to work I had to drill down one more layer in the response from the API. Otherwise I was getting an error from xml-js because it couldn't parse an Object.